### PR TITLE
Add settings reload and schedule info

### DIFF
--- a/multimouse.pyw
+++ b/multimouse.pyw
@@ -76,6 +76,11 @@ AUTOTIKTOK_DIR = BASE_DIR / "AutoTikTok"
 for d in (BASE_DIR, AUTOSNAP_DIR, AUTOMOUSE_DIR, AUTOTIKTOK_DIR):
     d.mkdir(parents=True, exist_ok=True)
 
+# Extra opslaglocatie voor gecombineerde instellingen
+EXTRA_SAVE_DIR = Path("bestanden/multimouse/kalibratie")
+EXTRA_SAVE_DIR.mkdir(parents=True, exist_ok=True)
+EXTRA_SAVE_FILE = EXTRA_SAVE_DIR / "instellingen.txt"
+
 # .ico bestanden naast dit .pyw
 APP_ICON_MM = res_path("inputmouse_92614.ico")                  # muis icoon (hoofdmenu)
 APP_ICON_SNAP = res_path("snapchat_black_logo_icon_147080.ico") # snapchat icoon
@@ -114,6 +119,9 @@ LANGS = {
         "move_mouse_to": "Beweeg je muis naar:\n{target}",
         "dark_mode": "Donkere modus",
         "language": "Taal",
+        "save_settings": "Instellingen opslaan",
+        "load_settings": "Instellingen laden",
+        "loaded": "Ingeladen",
         "play_delay": "Delay tussen herhalingen (seconden)",
         "waiting_for_insert": "Wachten op INSERT",
         "press_insert_to_start": "Druk op INSERT om te starten (ESC annuleert)",
@@ -175,6 +183,9 @@ LANGS = {
         "move_mouse_to": "Move your mouse to:\n{target}",
         "dark_mode": "Dark mode",
         "language": "Language",
+        "save_settings": "Save settings",
+        "load_settings": "Load settings",
+        "loaded": "Loaded",
         "play_delay": "Delay between repeats (seconds)",
         "waiting_for_insert": "Waiting for INSERT",
         "press_insert_to_start": "Press INSERT to start (ESC to cancel)",
@@ -493,10 +504,10 @@ def calibrate_position_snap(root: tk.Tk, target_label: str):
         _exit_calibration_mini(root, prev_state)
 
 class AutoSnapWindow(tk.Toplevel, MiniMixin):
-    def __init__(self, master, get_lang, set_lang):
+    def __init__(self, master, get_lang, set_lang, save_combined):
         tk.Toplevel.__init__(self, master)
         MiniMixin.__init__(self)
-        self.get_lang = get_lang; self.set_lang = set_lang
+        self.get_lang = get_lang; self.set_lang = set_lang; self.save_combined = save_combined
         self.title(tr("autosnap")); set_window_icon(self, APP_ICON_SNAP)
         self.geometry("900x1040"); self.resizable(True, True); self.attributes("-topmost", True)
 
@@ -562,8 +573,9 @@ class AutoSnapWindow(tk.Toplevel, MiniMixin):
         self._build_responder(self.responder_frame)
         self._build_combi(self.combi_frame)
 
+        ttk.Button(wrap, text=tr("save_settings"), command=self.save_combined).grid(row=2, column=0, sticky="e", pady=(0,5))
         self.status_lbl = ttk.Label(wrap, textvariable=self.status_var, font=("Segoe UI", 10, "italic"))
-        self.status_lbl.grid(row=2, column=0, sticky="w")
+        self.status_lbl.grid(row=3, column=0, sticky="w")
 
         self._refresh_mode()
 
@@ -626,6 +638,7 @@ class AutoSnapWindow(tk.Toplevel, MiniMixin):
         self.times_list = tk.Listbox(sch, height=6)
         self.times_list.grid(row=1, column=0, columnspan=2, sticky="nsew", padx=(8,6), pady=6)
         self.times_list.bind("<<ListboxSelect>>", lambda e: self._load_people_for_selected_time())
+        self.times_list.bind("<Double-Button-1>", lambda e: self._show_time_people())
         ttk.Button(sch, text=tr("remove_time"), command=self._remove_time).grid(row=1, column=2, padx=6, sticky="nw")
 
         self.time_people_vars = [tk.BooleanVar(value=False) for _ in range(8)]
@@ -703,6 +716,7 @@ class AutoSnapWindow(tk.Toplevel, MiniMixin):
         self.combi_times_list = tk.Listbox(sch, height=6)
         self.combi_times_list.grid(row=1, column=0, columnspan=2, sticky="nsew", padx=(8,6), pady=6)
         self.combi_times_list.bind("<<ListboxSelect>>", lambda e: self._combi_load_people_for_selected_time())
+        self.combi_times_list.bind("<Double-Button-1>", lambda e: self._combi_show_time_people())
         ttk.Button(sch, text=tr("remove_time"), command=self._combi_remove_time).grid(row=1, column=2, padx=6, sticky="nw")
 
         self.combi_people_vars = [tk.BooleanVar(value=False) for _ in range(8)]
@@ -743,7 +757,12 @@ class AutoSnapWindow(tk.Toplevel, MiniMixin):
     def _calib_key(self, key, label_text):
         pos = calibrate_position_snap(self, label_text)
         if pos:
-            self.cfg[key] = pos; save_snap_config(self.cfg)
+            self.cfg[key] = pos
+            if key == "restart_close_app":
+                self.cfg["responder_close_snap"] = pos
+            elif key == "responder_close_snap":
+                self.cfg["restart_close_app"] = pos
+            save_snap_config(self.cfg)
             toast(self, tr("saved"), f"{label_text} -> {pos}", timeout=2000)
 
     def _calib_people(self):
@@ -797,6 +816,14 @@ class AutoSnapWindow(tk.Toplevel, MiniMixin):
         if not sel: return
         self.time_people[sel] = [bool(v.get()) for v in self.time_people_vars]
         self.cfg["combi_time_people"] = self.time_people; save_snap_config(self.cfg)
+
+    def _show_time_people(self):
+        sel = self._selected_time()
+        if not sel: return
+        mask = self.time_people.get(sel, [False]*8)
+        people = [f"P{i+1}" for i, on in enumerate(mask) if on]
+        text = ", ".join(people) if people else "Geen"
+        messagebox.showinfo(sel, text)
 
     def _click_xy(self, pos):
         x, y = pos
@@ -1059,6 +1086,14 @@ class AutoSnapWindow(tk.Toplevel, MiniMixin):
         self.combi_time_people[sel] = [bool(v.get()) for v in self.combi_people_vars]
         self.cfg["combi_time_people"] = self.combi_time_people; save_snap_config(self.cfg)
 
+    def _combi_show_time_people(self):
+        sel = self._combi_selected_time()
+        if not sel: return
+        mask = self.combi_time_people.get(sel, [False]*8)
+        people = [f"P{i+1}" for i, on in enumerate(mask) if on]
+        text = ", ".join(people) if people else "Geen"
+        messagebox.showinfo(sel, text)
+
     def _start_combi(self):
         required = [
             self.cfg.get("foto1"),
@@ -1148,11 +1183,28 @@ def load_tt_config():
 def save_tt_config(cfg):
     AUTOTIKTOK_CONFIG_FILE.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
 
+
+def load_combined_data():
+    """Laad gecombineerde instellingen uit EXTRA_SAVE_FILE en pas toe."""
+    if not EXTRA_SAVE_FILE.exists():
+        return None
+    try:
+        data = json.loads(EXTRA_SAVE_FILE.read_text(encoding="utf-8"))
+        snap = data.get("autosnap")
+        if isinstance(snap, dict):
+            save_snap_config(snap)
+        tt = data.get("autotiktok")
+        if isinstance(tt, dict):
+            save_tt_config(tt)
+        return data
+    except Exception:
+        return None
+
 class AutoTikTokWindow(tk.Toplevel, MiniMixin):
-    def __init__(self, master, get_lang, set_lang):
+    def __init__(self, master, get_lang, set_lang, save_combined):
         tk.Toplevel.__init__(self, master)
         MiniMixin.__init__(self)
-        self.get_lang = get_lang; self.set_lang = set_lang
+        self.get_lang = get_lang; self.set_lang = set_lang; self.save_combined = save_combined
         self.title(tr("autotiktok")); set_window_icon(self, APP_ICON_TT)
         self.geometry("740x780"); self.resizable(True, True); self.attributes("-topmost", True)
 
@@ -1202,7 +1254,8 @@ class AutoTikTokWindow(tk.Toplevel, MiniMixin):
         ttk.Button(sch, text=tr("remove_time"), command=self._remove_time).grid(row=1, column=2, padx=6, sticky="nw")
 
         ttk.Button(wrap, text=" " + tr("start"), command=self._start).grid(row=4, column=0, pady=12, sticky="ew")
-        ttk.Label(wrap, textvariable=self.status_var, font=("Segoe UI", 10, "italic")).grid(row=5, column=0, sticky="w")
+        ttk.Button(wrap, text=tr("save_settings"), command=self.save_combined).grid(row=5, column=0, pady=(0,8), sticky="e")
+        ttk.Label(wrap, textvariable=self.status_var, font=("Segoe UI", 10, "italic")).grid(row=6, column=0, sticky="w")
 
     def _full_calibration(self):
         sequence = [("upload", "Upload"), ("select_video", tr("select_video")),
@@ -1622,6 +1675,11 @@ class AutoMouseWindow(tk.Toplevel, MiniMixin):
 # -----------------------------------------------------------------------------
 class MultiMouseApp:
     def __init__(self):
+        data = load_combined_data() or {}
+        lang = data.get("language", CURRENT_LANG)
+        globals()["CURRENT_LANG"] = lang
+        dark_mode = bool(data.get("dark_mode", True))
+
         self.root = None; self.style = None; self.using_tb = tb is not None
         if self.using_tb:
             self.root = tb.Window(themename="darkly"); self.style = tb.Style()
@@ -1632,14 +1690,15 @@ class MultiMouseApp:
 
         self.root.title(tr("app_title"))
         self.root.geometry("900x560"); self.root.resizable(True, True)
-        # Belangrijk: hoofdmenu NIET topmost, zodat het op achtergrond blijft
         self.root.attributes("-topmost", False)
         set_window_icon(self.root, APP_ICON_MM)
 
-        self.lang_var = tk.StringVar(value=CURRENT_LANG)
-        self.dark_var = tk.BooleanVar(value=True)
+        self.lang_var = tk.StringVar(value=lang)
+        self.dark_var = tk.BooleanVar(value=dark_mode)
+        self.dirty = False
 
         self._build_ui(); self._apply_theme(initial=True)
+        self.root.protocol("WM_DELETE_WINDOW", self._on_close)
 
     def _build_ui(self):
         wrap = ttk.Frame(self.root, padding=16); wrap.grid(row=0, column=0, sticky="nsew")
@@ -1666,8 +1725,12 @@ class MultiMouseApp:
         chk = ttk.Checkbutton(bar, variable=self.dark_var, command=self._apply_theme)
         chk.grid(row=0, column=3, padx=4, sticky="w")
 
+        ttk.Button(wrap, text=tr("load_settings"), command=self.load_combined_settings).grid(row=3, column=0, columnspan=3, pady=(0,4), sticky="ew")
+        ttk.Button(wrap, text=tr("save_settings"), command=self.save_combined_settings).grid(row=4, column=0, columnspan=3, pady=8, sticky="ew")
+
     def _switch_lang(self, val):
         globals()["CURRENT_LANG"] = val
+        self.dirty = True
         for w in list(self.root.children.values()): w.destroy()
         self._build_ui(); self._apply_theme()
 
@@ -1692,6 +1755,43 @@ class MultiMouseApp:
                 self.style.configure("TLabelframe.Label", background=bg, foreground=fg)
                 self.style.map("TButton", foreground=[("disabled", "#888888")])
             except Exception: pass
+        if not initial:
+            self.dirty = True
+
+    def save_combined_settings(self):
+        data = {
+            "language": self.lang_var.get(),
+            "dark_mode": bool(self.dark_var.get()),
+            "autosnap": load_snap_config(),
+            "autotiktok": load_tt_config(),
+        }
+        try:
+            EXTRA_SAVE_DIR.mkdir(parents=True, exist_ok=True)
+            EXTRA_SAVE_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")
+            messagebox.showinfo(tr("save_settings"), tr("saved"))
+            self.dirty = False
+        except Exception:
+            messagebox.showerror(tr("save_settings"), "Kon instellingen niet opslaan")
+
+    def load_combined_settings(self):
+        data = load_combined_data()
+        if not data:
+            messagebox.showerror(tr("load_settings"), "Geen opgeslagen instellingen")
+            return
+        self.lang_var.set(data.get("language", self.lang_var.get()))
+        self.dark_var.set(bool(data.get("dark_mode", False)))
+        self._switch_lang(self.lang_var.get())
+        self._apply_theme()
+        messagebox.showinfo(tr("load_settings"), tr("loaded"))
+        self.dirty = False
+
+    def _on_close(self):
+        if self.dirty:
+            msg = ("Wilt u uw data opslaan?\n" "Niet opgeslagen: kalibratie, aantal snaps, tijden & personen, TikTok beschrijving, taal, thema")
+            detail = "Wordt opgeslagen: kalibratie, aantal snaps, tijden met personen, TikTok beschrijving, taal en thema"
+            if messagebox.askyesno(tr("save_settings"), msg, detail=detail):
+                self.save_combined_settings()
+        self.root.destroy()
 
     def _show_child_modal(self, child_window: tk.Toplevel):
         # hoofdmenu blijft op achtergrond (niet topmost)
@@ -1710,9 +1810,10 @@ class MultiMouseApp:
         self.root.deiconify()
 
     def open_autosnap(self):
-        w = AutoSnapWindow(self.root, lambda: self.lang_var.get(), self._switch_lang)
+        w = AutoSnapWindow(self.root, lambda: self.lang_var.get(), self._switch_lang, self.save_combined_settings)
         set_window_icon(w, APP_ICON_SNAP)
         self._show_child_modal(w)
+        self.dirty = True
 
     def open_automouse(self):
         w = AutoMouseWindow(self.root, lambda: self.lang_var.get(), self._switch_lang)
@@ -1720,9 +1821,10 @@ class MultiMouseApp:
         self._show_child_modal(w)
 
     def open_autotiktok(self):
-        w = AutoTikTokWindow(self.root, lambda: self.lang_var.get(), self._switch_lang)
+        w = AutoTikTokWindow(self.root, lambda: self.lang_var.get(), self._switch_lang, self.save_combined_settings)
         set_window_icon(w, APP_ICON_TT)
         self._show_child_modal(w)
+        self.dirty = True
 
 # -----------------------------------------------------------------------------
 # Main


### PR DESCRIPTION
## Summary
- Load combined settings on startup and via new "load settings" button
- Share sender/responder close calibration and show scheduled people on time double-click
- Expanded exit prompt with info about unsaved data

## Testing
- `python -m py_compile multimouse.pyw`


------
https://chatgpt.com/codex/tasks/task_e_689ef719c6dc832ea1510e316e8e0ff5