### PR TITLE
Add customtkinter UI and configurable settings paths

### DIFF
--- a/multimouse.pyw
+++ b/multimouse.pyw
@@ -1731,8 +1731,10 @@ class MultiMouseApp:
         ctk.set_appearance_mode("dark" if is_dark else "light")
         bg = "#1e1e1e" if is_dark else "#f0f0f0"; fg = "#f5f5f5" if is_dark else "#111111"
         try:
-            self.root.configure(bg=bg)
-        except Exception: pass
+            # use CTk's fg_color so foreground text isn't white on a white window
+            self.root.configure(fg_color=bg)
+        except Exception:
+            pass
         try:
             self.style.configure(".", background=bg, foreground=fg)
             self.style.configure("TLabel", background=bg, foreground=fg)


### PR DESCRIPTION
## Summary
- migrate main window and modules to customtkinter so AutoSnap, AutoMouse and AutoTikTok open CTk menus
- allow choosing custom file paths when saving or loading combined settings

## Testing
- `python -m py_compile multimouse.pyw`


------
https://chatgpt.com/codex/tasks/task_e_68a32f2ce69c832e81bcbc48ddddc947