### PR TITLE
Add startup toggle and improve UI scaling

### DIFF
--- a/autosnap_startup.py
+++ b/autosnap_startup.py
@@ -1,4 +1,4 @@
-import sys, time
+import sys, time, importlib
 import tkinter as tk
 from tkinter import messagebox
 
@@ -14,15 +14,17 @@ def _fatal(msg: str):
     sys.exit(1)
 
 
-try:
-    import customtkinter as ctk  # type: ignore
-except Exception:
-    _fatal("CustomTkinter ontbreekt. Installeer met: pip install customtkinter")
+def _require_module(name: str, pip_hint: str):
+    try:
+        mod = importlib.import_module(name)
+        path = getattr(mod, "__file__", "builtin")
+        print(f"{name} -> {path}")
+        return mod
+    except Exception as e:
+        _fatal(f"{pip_hint} ontbreekt: {e}\nInstalleer met: pip install {pip_hint}")
 
-try:
-    import pyautogui  # type: ignore
-except Exception:
-    _fatal("PyAutoGUI en Pillow moeten geïnstalleerd zijn.\nGebruik: pip install pyautogui pillow")
+ctk = _require_module("customtkinter", "customtkinter")  # type: ignore
+pyautogui = _require_module("pyautogui", "pyautogui pillow")  # type: ignore
 
 from multimouse import (
     load_combined_data,

--- a/multimouse.pyw
+++ b/multimouse.pyw
@@ -8,7 +8,7 @@ Modules:
 - AutoTikTok (upload flow)
 """
 
-import os, sys, json, time, ctypes, threading, shutil
+import os, sys, json, time, ctypes, threading, shutil, importlib
 from pathlib import Path
 from datetime import datetime, timedelta
 
@@ -28,26 +28,28 @@ def _fatal(msg: str):
     sys.exit(1)
 
 
-try:
-    import customtkinter as ctk  # type: ignore
-except Exception:
-    _fatal("CustomTkinter ontbreekt. Installeer met: pip install customtkinter")
+def _require_module(name: str, pip_hint: str):
+    """Import a module and show its location; exit if missing."""
+    try:
+        mod = importlib.import_module(name)
+        path = getattr(mod, "__file__", "builtin")
+        print(f"{name} -> {path}")
+        return mod
+    except Exception as e:
+        _fatal(f"{pip_hint} ontbreekt: {e}\nInstalleer met: pip install {pip_hint}")
 
-try:
-    import pyautogui  # type: ignore
-except Exception:
-    _fatal("PyAutoGUI en Pillow moeten geïnstalleerd zijn.\nGebruik: pip install pyautogui pillow")
-
+ctk = _require_module("customtkinter", "customtkinter")  # type: ignore
+pyautogui = _require_module("pyautogui", "pyautogui pillow")  # type: ignore
 try:
     from PIL import Image, ImageTk  # type: ignore
-except Exception:
+    print(f"Pillow -> {Image.__file__}")
+except Exception as e:
     Image = ImageTk = None  # icon fallback wanneer Pillow ontbreekt
+    print(f"Pillow ontbreekt: {e}")
 
-try:
-    from pynput import keyboard, mouse  # type: ignore
-    from pynput.keyboard import Key  # type: ignore
-except Exception:
-    _fatal("pynput ontbreekt. Installeer met: pip install pynput")
+pynput = _require_module("pynput", "pynput")  # type: ignore
+from pynput import keyboard, mouse  # type: ignore
+from pynput.keyboard import Key  # type: ignore
 
 # -----------------------------------------------------------------------------
 # Windows AUMID (taskbar grouping)


### PR DESCRIPTION
## Summary
- add Windows startup helpers and config toggle in AutoSnap settings
- set Snapchat icon for startup script so taskbar shows proper logo
- configure window layouts to scale with resizing across the app
- add a gear button in AutoSnap that opens a settings window with startup toggle and calibration
- rename startup script to `autosnap_startup.py` and update references
- exit with a clear error message when required libraries like CustomTkinter, PyAutoGUI or Pillow are missing

## Testing
- `python -m py_compile multimouse.pyw autosnap_startup.py`


------
https://chatgpt.com/codex/tasks/task_e_68a32f2ce69c832e81bcbc48ddddc947