### PR TITLE
Improve AutoSnap startup timing

### DIFF
--- a/autosnap_startup.py
+++ b/autosnap_startup.py
@@ -59,16 +59,18 @@ def open_snapchat(cfg, delay):
     if not search:
         return
     x, y = search
-    with log_action("Wachten na opstart (5s)"):
-        time.sleep(5.0)
+    with log_action("Wachten na opstart (10s)"):
+        time.sleep(10.0)
     with log_action("Beweeg naar zoekbalk"):
         pyautogui.moveTo(x, y, duration=delay)
-    time.sleep(delay)
+    time.sleep(1.0)
     with log_action("Klik op zoekbalk"):
         pyautogui.click()
+    time.sleep(2.0)
     try:
         with log_action("Typ 'snapchat' en druk Enter"):
             pyautogui.typewrite("snapchat", interval=0.01)
+            time.sleep(1.0)
             pyautogui.press("enter")
     except Exception:
         pass


### PR DESCRIPTION
## Summary
- extend initial AutoSnap wait to 10s
- add pauses between moving, clicking and typing

## Testing
- `python -m py_compile autosnap_startup.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd934ee518832e80df687208b37a04