### PR TITLE
Add optional startup delay for AutoSnap Combi

### DIFF
--- a/autosnap_combi.pyw
+++ b/autosnap_combi.pyw
@@ -14,6 +14,8 @@ mm = _load_mm()
 
 def open_snapchat():
     cfg = mm.load_snap_config()
+    if cfg.get("startup_delay"):
+        time.sleep(10.0)
     link = cfg.get("snapchat_shortcut") or (Path.home() / "Desktop" / "Snapchat.lnk")
     link = Path(link)
     if not link.exists():
@@ -21,6 +23,7 @@ def open_snapchat():
         return
     os.startfile(str(link))
     time.sleep(5.0)
+    mm.close_spotlight(cfg)
 
 
 def main():


### PR DESCRIPTION
## Summary
- add configuration and UI toggle for a 10s startup delay
- add calibration and helper to close Snapchat Spotlight after launch or restart
- respect the delay and dismiss Spotlight when launching AutoSnap Combi

## Testing
- `python -m py_compile autosnap_combi.pyw multimouse.pyw`


------
https://chatgpt.com/codex/tasks/task_e_68c6cb2be5e0832ea3ca05c826a5e327