### PR TITLE
Add AutoSnap story editor automation

### DIFF
--- a/autosnap_combi.pyw
+++ b/autosnap_combi.pyw
@@ -14,6 +14,8 @@ mm = _load_mm()
 
 def open_snapchat():
     cfg = mm.load_snap_config()
+    if cfg.get("startup_delay"):
+        time.sleep(10.0)
     link = cfg.get("snapchat_shortcut") or (Path.home() / "Desktop" / "Snapchat.lnk")
     link = Path(link)
     if not link.exists():
@@ -21,6 +23,7 @@ def open_snapchat():
         return
     os.startfile(str(link))
     time.sleep(5.0)
+    mm.close_spotlight(cfg)
 
 
 def main():

--- a/autosnap_story.pyw
+++ b/autosnap_story.pyw
@@ -1,0 +1,63 @@
+import importlib.util, pathlib, sys, os, time
+from pathlib import Path
+
+
+def _load_mm():
+    path = pathlib.Path(__file__).with_name("multimouse.pyw")
+    spec = importlib.util.spec_from_file_location("_mm", path)
+    mm = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault("_mm", mm)
+    spec.loader.exec_module(mm)  # type: ignore[attr-defined]
+    return mm
+
+
+mm = _load_mm()
+
+
+def open_snapchat():
+    cfg = mm.load_snap_config()
+    link = cfg.get("snapchat_shortcut") or (Path.home() / "Desktop" / "Snapchat.lnk")
+    link = Path(link)
+    if not link.exists():
+        print(f"Shortcut niet gevonden: {link}")
+        return cfg
+    try:
+        os.startfile(str(link))
+    except Exception as exc:
+        print(f"Kon Snapchat niet starten: {exc}")
+        return cfg
+    time.sleep(5.0)
+    try:
+        mm.close_spotlight(cfg)
+    except Exception:
+        pass
+    return cfg
+
+
+def main():
+    open_snapchat()
+    app = mm.MultiMouseApp()
+    app.root.withdraw()
+    win = mm.AutoSnapWindow(
+        app.root,
+        lambda: app.lang_var.get(),
+        app._switch_lang,
+        app.save_combined_settings,
+        app.load_combined_settings,
+    )
+    mm.set_window_icon(win, mm.APP_ICON_SNAP)
+    app._apply_theme(mark_dirty=False)
+    win.mode_var.set("story")
+    win._refresh_mode()
+    win.deiconify()
+    win.lift()
+    win.focus_force()
+    win._start_story()
+    app.root.mainloop()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        mm._fatal(f"Onverwachte fout: {e}")


### PR DESCRIPTION
## Summary
- add a Story editor mode to AutoSnap with dedicated calibrations and 1-second story sending automation
- extend translations/config defaults for the story workflow and integrate the new mode into the UI
- add an autosnap_story launcher that opens Snapchat, waits 5 seconds, then starts the story automation

## Testing
- `python -m py_compile autosnap_combi.pyw autosnap_story.pyw multimouse.pyw`


------
https://chatgpt.com/codex/tasks/task_e_68c6cb2be5e0832ea3ca05c826a5e327