### PR TITLE
Ensure 3s delay before sending reply

### DIFF
--- a/multimouse.pyw
+++ b/multimouse.pyw
@@ -1472,6 +1472,7 @@ class AutoSnapWindow(ctk.CTkToplevel, MiniMixin):
                 pyautogui.click()
                 time.sleep(1)
                 pyautogui.click()
+                second_click_time = time.time()
                 time.sleep(1)
 
                 foto_pos = self.cfg.get("foto_reply") or self.cfg.get("foto1")
@@ -1486,6 +1487,9 @@ class AutoSnapWindow(ctk.CTkToplevel, MiniMixin):
                 if not s2:
                     return False
                 sx, sy = s2
+                elapsed = time.time() - second_click_time
+                if elapsed < 3:
+                    time.sleep(3 - elapsed)
                 pyautogui.moveTo(sx, sy, duration=move_dur)
                 pyautogui.click()
                 time.sleep(1)


### PR DESCRIPTION
## Summary
- record the timestamp of the second red-block click in the reply flow
- ensure at least three seconds pass before activating the send reply button

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f083699e08321b0ff6e3f11878877)